### PR TITLE
chore(ci): use github action instead of travis

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+name: Continous Integration
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-cache:
-  yarn: true
-script:
-  - yarn lint
-  - yarn test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# sprintf-mock [![Build Status](https://api.travis-ci.org/M6Web/sprintf-mock.png?branch=master)](https://travis-ci.org/M6Web/sprintf-mock)
+# sprintf-mock
 
 [sprintf-js](https://github.com/alexei/sprintf.js) plugin allowing to mock sprintf behaviour by returning data fixtures based on the resolved pattern and parameters. For example, it's useful if you build some external resources URLs in your app with sprintf and you rather want to request local resources in your functional tests.
 


### PR DESCRIPTION
- github action is quite fresh and easier to user for package publication
- handle full CI with it
- setup cache for dependencies
